### PR TITLE
Enable creating items from all of the pages

### DIFF
--- a/doc/index.md
+++ b/doc/index.md
@@ -82,6 +82,27 @@ $page->getItems(); // [2, 4]
 ?>
 ```
 
+### Getting items from all of the pages
+
+Sometimes it might be necessary to keep using the paging system yet fetch all
+items from all of the pages.
+
+```php
+<?php
+
+use KG\Pager\Pager;
+use KG\Pager\Adapter\ArrayAdapter;
+
+$perPage = 2;
+$pager = new Pager();
+$page = $pager->paginate(new ArrayAdapter(range(0, 3)), $perPage);
+
+$page->getItems(); // [0, 1]
+$page->getItemsOfAllPages(); // [0, 1, 2, 3]
+
+?>
+```
+
 ### Avoiding expensive counting
 
 On bigger result sets it might be prohibitively expensive to count the total

--- a/src/Page.php
+++ b/src/Page.php
@@ -85,6 +85,17 @@ final class Page implements PageInterface
     /**
      * {@inheritDoc}
      */
+    public function getItemsOfAllPages()
+    {
+        // @todo this is suboptimal - ideally we don't need to know item count
+        // to get all items. Instead the entire collection should be returned.
+        // Doing it this way to minimize BC breaks.
+        return $this->adapter->getItems(0, $this->getItemCount());
+    }
+
+    /**
+     * {@inheritDoc}
+     */
     public function getNumber()
     {
         return $this->number;

--- a/src/PageInterface.php
+++ b/src/PageInterface.php
@@ -26,6 +26,13 @@ interface PageInterface
     public function getItems();
 
     /**
+     * @return array Items from all of the pages
+     *
+     * @api
+     */
+    public function getItemsOfAllPages();
+
+    /**
      * @return integer 1-indexed number of this page within the page collection
      *
      * @api

--- a/tests/PageTest.php
+++ b/tests/PageTest.php
@@ -31,6 +31,31 @@ class PageTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($expected, $page->getItems());
     }
 
+    public function testItemsOfAllPagesReturnsItemsFromAllPages()
+    {
+        $expected = range(0, 8);
+
+        $strategy = $this->getMockStrategy();
+
+        $adapter = $this->getMockAdapter();
+        $adapter
+            ->method('getCount')
+            ->will($this->returnCallback(function () use ($expected) {
+                return count($expected);
+            }))
+        ;
+
+        $adapter
+            ->method('getItems')
+            ->will($this->returnCallback(function ($offset, $limit) use ($expected) {
+                return array_slice($expected, $offset, $limit);
+            }))
+        ;
+
+        $page = new Page($adapter, $strategy, 2, 2);
+        $this->assertEquals($expected, $page->getItemsOfAllPages());
+    }
+
     public function testExtraItemFetched()
     {
         $strategy = $this->getMockStrategy();


### PR DESCRIPTION
Makes it possible to fetch all items from all pages via a single page element. It's useful in situations where you don't want to duplicate the logic of fetching items.