### PR TITLE
Deprecate passing QueryBuilder to DqlAdapter::fromQuery

### DIFF
--- a/src/Adapter.php
+++ b/src/Adapter.php
@@ -11,6 +11,7 @@
 
 namespace KG\Pager;
 
+use Doctrine\ORM\QueryBuilder;
 use Elastica\Search;
 use KG\Pager\Adapter\ArrayAdapter;
 use KG\Pager\Adapter\DqlAdapter;
@@ -54,7 +55,26 @@ final class Adapter
      */
     public static function dql($query, $fetchJoinCollection = true)
     {
+        if ($query instanceof QueryBuilder) {
+            @trigger_error('Using QueryBuilder with Adapter::dql() is deprecated and will be removed in 2.0. Please use Adapter::dqlByQueryBuilder() instead.', E_USER_DEPRECATED);
+
+            return static::dqlByQueryBuilder($query);
+        }
+
         return DqlAdapter::fromQuery($query, $fetchJoinCollection);
+    }
+
+    /**
+     * @param QueryBuilder $qb
+     * @param boolean      $fetchJoinCollection
+     *
+     * @return DqlAdapter
+     *
+     * @api
+     */
+    public static function dqlByQueryBuilder(QueryBuilder $qb,  $fetchJoinCollection = true)
+    {
+        return DqlAdapter::fromQueryBuilder($qb, $fetchJoinCollection);
     }
 
     /**

--- a/src/Adapter/DqlAdapter.php
+++ b/src/Adapter/DqlAdapter.php
@@ -11,6 +11,7 @@
 
 namespace KG\Pager\Adapter;
 
+use Doctrine\ORM\QueryBuilder;
 use Doctrine\ORM\Tools\Pagination\Paginator;
 use KG\Pager\AdapterInterface;
 
@@ -54,8 +55,8 @@ final class DqlAdapter implements AdapterInterface
     /**
      * @see Paginator
      *
-     * @param \Doctrine\ORM\Query|\Doctrine\ORM\QueryBuilder $query               A Doctrine ORM query or query builder.
-     * @param boolean                                        $fetchJoinCollection Whether the query joins a collection (true by default).
+     * @param \Doctrine\ORM\Query $query               A Doctrine ORM query or query builder.
+     * @param boolean             $fetchJoinCollection Whether the query joins a collection (true by default).
      *
      * @return SimpleDqlAdapter
      *
@@ -63,7 +64,26 @@ final class DqlAdapter implements AdapterInterface
      */
     public static function fromQuery($query, $fetchJoinCollection = true)
     {
+        if ($query instanceof QueryBuilder) {
+            @trigger_error('Using QueryBuilder with DqlAdapter::fromQuery() is deprecated and will be removed in 2.0. Please use DqlAdapter::fromQueryBuilder() instead.', E_USER_DEPRECATED);
+        }
+
         return new static(new Paginator($query, $fetchJoinCollection));
+    }
+
+    /**
+     * @see Paginator
+     *
+     * @param QueryBuilder $query               A Doctrine ORM query builder.
+     * @param boolean      $fetchJoinCollection Whether the query joins a collection (true by default).
+     *
+     * @return SimpleDqlAdapter
+     *
+     * @api
+     */
+    public static function fromQueryBuilder(QueryBuilder $qb, $fetchJoinCollection = true)
+    {
+        return new static(new Paginator($qb, $fetchJoinCollection));
     }
 
     /**

--- a/tests/Adapter/DqlAdapterTest.php
+++ b/tests/Adapter/DqlAdapterTest.php
@@ -73,6 +73,12 @@ class DqlAdapterTest extends \PHPUnit_Framework_TestCase
         $adapter = DqlAdapter::fromQuery($query);
     }
 
+    public function testFromQueryBuilder()
+    {
+        $qb = $this->getMockQueryBuilder();
+        $adapter = DqlAdapter::fromQueryBuilder($qb);
+    }
+
     private function getMockPaginator()
     {
         return $this
@@ -89,6 +95,15 @@ class DqlAdapterTest extends \PHPUnit_Framework_TestCase
             ->setMethods(array('setParameter', 'getResult', 'getQuery', 'setFirstResult', 'setMaxResults'))
             ->disableOriginalConstructor()
             ->getMockForAbstractClass()
+        ;
+    }
+
+    private function getMockQueryBuilder()
+    {
+        return $this
+            ->getMockBuilder('\Doctrine\ORM\QueryBuilder')
+            ->disableOriginalConstructor()
+            ->getMock()
         ;
     }
 }

--- a/tests/AdapterTest.php
+++ b/tests/AdapterTest.php
@@ -37,6 +37,16 @@ class AdapterTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf('KG\Pager\Adapter\DqlAdapter', Adapter::dql($query));
     }
 
+    public function testDqlByQueryBuilder()
+    {
+        if (!class_exists('Doctrine\ORM\QueryBuilder')) {
+            $this->markTestSkipped('doctrine/orm must be installed to run this test');
+        }
+
+        $qb = $this->getMockQueryBuilder();
+        $this->assertInstanceOf('KG\Pager\Adapter\DqlAdapter', Adapter::dqlByQueryBuilder($qb));
+    }
+
     public function testDqlByHand()
     {
         if (!class_exists('Doctrine\ORM\Query')) {
@@ -80,6 +90,15 @@ class AdapterTest extends \PHPUnit_Framework_TestCase
     {
         return $this
             ->getMockBuilder('\Doctrine\ORM\AbstractQuery')
+            ->disableOriginalConstructor()
+            ->getMockForAbstractClass()
+        ;
+    }
+
+    private function getMockQueryBuilder()
+    {
+        return $this
+            ->getMockBuilder('\Doctrine\ORM\QueryBuilder')
             ->disableOriginalConstructor()
             ->getMockForAbstractClass()
         ;


### PR DESCRIPTION
Starting from 2.0 the way to use Doctrine's QueryBuilder with DqlAdapter
is to use `DqlAdapter::fromQueryBuilder` instead.